### PR TITLE
Remove _format_version from config YAML

### DIFF
--- a/smk-deploy/createGWAConfig.py
+++ b/smk-deploy/createGWAConfig.py
@@ -36,7 +36,6 @@ class GWAConfig:
     def createYaml(self):
         yamlData = \
             { 
-                "_format_version": "1.1",
                 "services": [
                     {
                         "name": self.OCService,


### PR DESCRIPTION
A validation rule was recently added that invalidates underscores in YAML properties. This change removes a property containing underscores that is causing deploy failures.