### PR TITLE
Updates to versions, registry

### DIFF
--- a/smk-build/action.yaml
+++ b/smk-build/action.yaml
@@ -29,7 +29,6 @@ runs:
         echo REPO $REPO
 
         DATESTAMP=$(date +%Y%m%d-%H%M)
-        #REGISTRY="docker.pkg.github.com"
         REGISTRY=${{ inputs.DOCKER_REGISTRY }}
         repolowercase=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
         IMAGE="${REGISTRY}/$repolowercase/$REPO"
@@ -95,8 +94,6 @@ runs:
         echo GITHUBOWNERREPO $GITHUBOWNERREPO
         echo GITHHUBREPO $GITHHUBREPO
         echo DOCKER_REPO $DOCKER_REPO
-
-        #DOCKER_IMAGE_PATH=docker.pkg.github.com/$GITHUBOWNER-REPO/$GITHHUBREPO:
 
         echo ${{ inputs.GHCR_TOKEN }} | docker login https://${{ inputs.DOCKER_REGISTRY }} -u ${{ inputs.GHCR_USER }} --password-stdin
         docker build -t $DOCKER_REPO .

--- a/smk-build/build_notes.md
+++ b/smk-build/build_notes.md
@@ -12,12 +12,12 @@ openshift.  creates a docker image, uploads to github packages.
 * GHCR_USER             github user who has a personal access token configured
                         for access to the repos packages
 * GHCR_TOKEN            the personal access token for the user above
-* DOCKER_REGISTRY       the path to the docker registry (docker.pkg.github.com)
+* DOCKER_REGISTRY       the path to the docker registry (ghcr.io)
 
 ## Output Parameters
 
 * Docker version tag        ${{ steps.calculateImageTag.outputs.DOCKER_VERSION_TAG }}
-  example: (docker.pkg.github.com/frantarkenton/smk-fap-fcb/smk-fap-fcb:20210123-0244)
+  example: (ghcr.io/frantarkenton/smk-fap-fcb/smk-fap-fcb:20210123-0244)
 * timestamp                 ${{ steps.calculateImageTag.outputs.TIMESTAMPTAG }}
 * repo name                 ${{ steps.calculateImageTag.outputs.REPO }} 
   (example: smk-fap-fcb )

--- a/smk-deploy/deploy_notes.md
+++ b/smk-deploy/deploy_notes.md
@@ -52,7 +52,7 @@ Dev deploys will perform the following steps:
 * Extract the github repo name from the 'github.repository' parameter
     and make available `${{ steps.getRepo.outputs.REPONAME }}`
 * Get the email address associated with the input `GHCR_USER`
-* Calculate the Github container registry path (example... `docker.pkg.github.com/bcgov/smk-fap-fcb/smk-fap-fcb`)
+* Calculate the Github container registry path (example... `ghcr.io/bcgov/smk-fap-fcb/smk-fap-fcb`)
 * Extract the image tag from the configmap `$REPONAME-imagetag-cm` (example: `20210122-0059` )
 * Extract the issue url that was populated into the dev namespace config map.  (this should be changed, see this
   step for notes)

--- a/smk-deploy/getDockerInfo.py
+++ b/smk-deploy/getDockerInfo.py
@@ -23,4 +23,4 @@ class test:
 
     def populateArgs(self):
         repoName = 'franTarkenton/smk-fap-fcp-comp'
-        registry = 'docker.pkg.github.com'
+        registry = 'ghcr.io'

--- a/smk-publish-app/.github/workflows/build-deploy-dev.yaml
+++ b/smk-publish-app/.github/workflows/build-deploy-dev.yaml
@@ -29,7 +29,7 @@ jobs:
 
     name: 'Build SMK container image'
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       OPENSHIFT_SERVER_URL: ${{secrets.OPENSHIFT_SERVER_URL}}
       OPENSHIFT_TOKEN_DEV: ${{secrets.OPENSHIFT_TOKEN_DEV}}
@@ -40,7 +40,7 @@ jobs:
       
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       if: env.OPENSHIFT_SERVER_URL != '' &&  env.OPENSHIFT_TOKEN_DEV != '' && env.GHCR_USER != '' && env.GHCR_TOKEN != ''
       id: checkout
       with:
@@ -55,7 +55,7 @@ jobs:
         OPENSHIFT_TOKEN_DEV: ${{ secrets.OPENSHIFT_TOKEN_DEV }}
         GHCR_USER: ${{ secrets.GHCR_USER }}
         GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        DOCKER_REGISTRY: 'docker.pkg.github.com'
+        DOCKER_REGISTRY: 'ghcr.io'
 
     - name: deploying dev
       uses: bcgov/smk-actions/smk-deploy@main
@@ -66,9 +66,6 @@ jobs:
         OPENSHIFT_TOKEN_DEV: ${{ secrets.OPENSHIFT_TOKEN_DEV }}
         GHCR_USER: ${{ secrets.GHCR_USER }}
         GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        DOCKER_REGISTRY: 'docker.pkg.github.com'
+        DOCKER_REGISTRY: 'ghcr.io'
         PR_REVIEWERS: '["michaelpnelson"]'
         PR_MENTIONS: '["michaelpnelson"]'
-
-
-

--- a/smk-publish-app/.github/workflows/deploy_prod.yaml
+++ b/smk-publish-app/.github/workflows/deploy_prod.yaml
@@ -26,7 +26,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       OPENSHIFT_SERVER_URL: ${{secrets.OPENSHIFT_SERVER_URL}}
       OPENSHIFT_TOKEN_DEV: ${{secrets.OPENSHIFT_TOKEN_DEV}}
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     # CHECKOUT THE CODE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       id: checkout
       if: env.OPENSHIFT_SERVER_URL != '' &&  env.OPENSHIFT_TOKEN_DEV != '' && env.GHCR_USER != '' && env.GHCR_TOKEN != ''
       with:
@@ -52,6 +52,6 @@ jobs:
         OPENSHIFT_TOKEN_PROD: ${{ secrets.OPENSHIFT_TOKEN_PROD }}
         GHCR_USER: ${{ secrets.GHCR_USER }}
         GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        DOCKER_REGISTRY: 'docker.pkg.github.com'
+        DOCKER_REGISTRY: 'ghcr.io'
         PR_REVIEWERS: '["michaelpnelson"]'
         PR_MENTIONS: '["michaelpnelson"]'

--- a/smk-publish-app/Dockerfile
+++ b/smk-publish-app/Dockerfile
@@ -1,6 +1,6 @@
 # stage 1: use npm to install dependencies into node_modules 
 #          directory
-FROM node:alpine3.12 AS BUILD_IMAGE
+FROM node:alpine3.20 AS BUILD_IMAGE
 
 #RUN ls -la / &&  ls -la /srv && mkdir /srv
 WORKDIR /srv


### PR DESCRIPTION
- Dockerfiles were updated to pull from node:alpine3.20 (from 3.12) to address warnings of an outdated npm version
- Actions run on “ubuntu-latest” (from “ubuntu-20.4”)
- The “actions/checkout” calls use v4 (from v2) to address warnings
- Docker registries are changed from “[docker.pkg.github.com](http://docker.pkg.github.com/)” to “ghcr.io”