### PR TITLE
Use earlier ubuntu version

### DIFF
--- a/smk-publish-app/.github/workflows/build-deploy-dev.yaml
+++ b/smk-publish-app/.github/workflows/build-deploy-dev.yaml
@@ -29,7 +29,7 @@ jobs:
 
     name: 'Build SMK container image'
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       OPENSHIFT_SERVER_URL: ${{secrets.OPENSHIFT_SERVER_URL}}
       OPENSHIFT_TOKEN_DEV: ${{secrets.OPENSHIFT_TOKEN_DEV}}

--- a/smk-publish-app/.github/workflows/deploy_prod.yaml
+++ b/smk-publish-app/.github/workflows/deploy_prod.yaml
@@ -26,7 +26,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       OPENSHIFT_SERVER_URL: ${{secrets.OPENSHIFT_SERVER_URL}}
       OPENSHIFT_TOKEN_DEV: ${{secrets.OPENSHIFT_TOKEN_DEV}}


### PR DESCRIPTION
This addresses an issue we saw with deploys running in ubuntu-latest. We found that if we specified this release instead of the latest release, the issue did not happen.